### PR TITLE
Fixed  linux compile with musl

### DIFF
--- a/ports/linux/termios2.h
+++ b/ports/linux/termios2.h
@@ -2,6 +2,12 @@
 #define TERMIOS2_H
 
 #define termios asmtermios /*avoid conflicts with others including termios.h*/
+/* for musl def TCGETS2 in asm-generic/ioctls.h */
+/* needs (int)sizeof(t) in _IOWR */
+/* asm-generic/ioctl.h */
+/* libc int ioctl (int, unsigned long int, ...) */
+/* musl int ioctl (int, int, ...) */
+#include <asm/ioctls.h>
 #include <asm/termbits.h>
 #undef termios
 


### PR DESCRIPTION
missing include asm/ioctls.h with error 'TCGETS2' undeclared

The gcc warning "overflow in conversion from 'long unsigned int' to 'int' changes value from '2150388778' to '-2144578518' " can be surrpres wtith a musl patch https://gist.github.com/stargieg/3dbfe94b5776d9dfb3e14d18ee43aade

from the musl mailing list with discussion on this bug, but no solution. [PATCH] ioctl: Fix implicit constant conversion overflow https://www.openwall.com/lists/musl/2024/06/01/1